### PR TITLE
fix worker timeout in cloud

### DIFF
--- a/docker/Dockerfile_flask
+++ b/docker/Dockerfile_flask
@@ -29,4 +29,4 @@ COPY . /geordash
 WORKDIR /geordash
 # this is entrypoint for dev
 #CMD ["flask", "-A", "geordash", "run", "--debug", "-h", "0.0.0.0", "-p", "5002"]
-CMD ["sh", "-c", "python3 -m gunicorn --log-level INFO 'geordash:create_app()'"]
+CMD ["sh", "-c", "python3 -m gunicorn --log-level INFO 'geordash:create_app()'  --timeout=0"]


### PR DESCRIPTION
deploying flask in the cloud create an error :
```
[7] [CRITICAL] WORKER TIMEOUT (pid:10) 
```

trying with disabling timeout as advice online for flash in cloud

reopening of local branch to try out the gh workflow