### PR TITLE
Avoid error 500 when finished task are in a strange state

### DIFF
--- a/geordash/result_backend/redisbackend.py
+++ b/geordash/result_backend/redisbackend.py
@@ -239,12 +239,13 @@ class RedisClient:
                             )
                         if date_done is not None:
                             taskids[taskid] = {"finished": date_done}
-                    found_taskids.append(
-                        {
-                            "id": taskid,
-                            "finished": taskids[taskid]["finished"].timestamp(),
-                        }
-                    )
+                    if taskids[taskid]["finished"] is not None:
+                        found_taskids.append(
+                            {
+                                "id": taskid,
+                                "finished": taskids[taskid]["finished"].timestamp(),
+                            }
+                        )
 
                 # remove taskids from the in-memory list
                 for t in dropped_taskids:


### PR DESCRIPTION
Protect the usage of `taskids[taskid]["finished"].timestamp(),` in case of broken task 

see https://github.com/georchestra/gaia/issues/29#issuecomment-3425936944
